### PR TITLE
Fix 'relations to itself' scenario when the architectural rule is of 'only' type

### DIFF
--- a/Source/ErosionFinder.Tests/HelpersTests/ArchitecturalRuleHelperTest.cs
+++ b/Source/ErosionFinder.Tests/HelpersTests/ArchitecturalRuleHelperTest.cs
@@ -121,6 +121,46 @@ namespace ErosionFinder.Helpers.Tests
                 $"{targetNamespace}.{targetStructureName}");
         }   
 
+        [Fact(DisplayName = "ArchitecturalRuleHelper GetViolatingOccurrences - Success: OnlyNeedToRelate relation type - Empty")]
+        [Trait(nameof(ArchitecturalRuleHelper.GetViolatingOccurrences), "Success_OnlyNeedToRelate_Empty")]
+        public void GetViolatingOccurrences_Success_OnlyNeedToRelate_Empty()
+        {
+            var architectureRule = new ArchitecturalRule()
+            {
+                OriginLayer = "Origin",
+                TargetLayer = "Target",
+                RuleOperator = RuleOperator.OnlyNeedToRelate
+            };
+
+            var targetNamespace = "Test.Target";
+            
+            var layersNamespaces = new Dictionary<string, IEnumerable<string>>()
+            {
+                { "Origin", new List<string>() { "Test.Origin" } },
+                { "Target", new List<string>() { targetNamespace } }
+            };
+
+            var structures = new List<Structure>() 
+            {
+                new Structure()
+                {
+                    Name = "TargetStructure",
+                    Type = StructureType.Class,
+                    Namespace = targetNamespace,
+                    References = new List<string>() { { targetNamespace } },
+                    Relations = new List<Relation>()
+                        { new Relation(RelationType.Inheritance, 
+                            targetNamespace, true, "AnotherTargetStructure") }
+                }
+            };
+
+            var violatingOccurrences = ArchitecturalRuleHelper.GetViolatingOccurrences(
+                architectureRule, layersNamespaces, structures);
+
+            Assert.NotNull(violatingOccurrences);
+            Assert.Empty(violatingOccurrences);
+        }
+
         [Fact(DisplayName = "ArchitecturalRuleHelper GetViolatingOccurrences - Success: OnlyCanRelate relation type")]
         [Trait(nameof(ArchitecturalRuleHelper.GetViolatingOccurrences), "Success_OnlyCanRelate")]
         public void GetViolatingOccurrences_Success_OnlyCanRelate()
@@ -170,6 +210,46 @@ namespace ErosionFinder.Helpers.Tests
             AssertViolatingOccurrences(violatingOccurrences, anotherStructure, 
                 $"{targetNamespace}.{targetStructureName}");
         }    
+
+        [Fact(DisplayName = "ArchitecturalRuleHelper GetViolatingOccurrences - Success: OnlyCanRelate relation type - Empty")]
+        [Trait(nameof(ArchitecturalRuleHelper.GetViolatingOccurrences), "Success_OnlyCanRelate_Empty")]
+        public void GetViolatingOccurrences_Success_OnlyCanRelate_Empty()
+        {
+            var architectureRule = new ArchitecturalRule()
+            {
+                OriginLayer = "Origin",
+                TargetLayer = "Target",
+                RuleOperator = RuleOperator.OnlyCanRelate
+            };
+
+            var targetNamespace = "Test.Target";
+            
+            var layersNamespaces = new Dictionary<string, IEnumerable<string>>()
+            {
+                { "Origin", new List<string>() { "Test.Origin" } },
+                { "Target", new List<string>() { targetNamespace } }
+            };
+
+            var structures = new List<Structure>() 
+            {
+                new Structure()
+                {
+                    Name = "TargetStructure",
+                    Type = StructureType.Class,
+                    Namespace = targetNamespace,
+                    References = new List<string>() { { targetNamespace } },
+                    Relations = new List<Relation>()
+                        { new Relation(RelationType.Inheritance, 
+                            targetNamespace, true, "AnotherTargetStructure") }
+                }
+            };
+
+            var violatingOccurrences = ArchitecturalRuleHelper.GetViolatingOccurrences(
+                architectureRule, layersNamespaces, structures);
+
+            Assert.NotNull(violatingOccurrences);
+            Assert.Empty(violatingOccurrences);
+        }
 
         [Fact(DisplayName = "ArchitecturalRuleHelper GetViolatingOccurrences - Success: CanNotRelate relation type")]
         [Trait(nameof(ArchitecturalRuleHelper.GetViolatingOccurrences), "Success_CanNotRelate")]

--- a/Source/ErosionFinder/Helpers/ArchitecturalRuleHelper.cs
+++ b/Source/ErosionFinder/Helpers/ArchitecturalRuleHelper.cs
@@ -86,9 +86,9 @@ namespace ErosionFinder.Helpers
                 .Select(s => 
                 {
                     var notAllowedRelations = s.Relations
-                        .Where(r => RelationTypeIsInDefinedList(r, relationTypes) 
-                            && targetNamespaces.Any(n => n.Equals(r.Target))
-                            && !s.Namespace.Equals(r.Target));
+                        .Where(r => !s.Namespace.Equals(r.Target)
+                            && RelationTypeIsInDefinedList(r, relationTypes) 
+                            && targetNamespaces.Any(n => n.Equals(r.Target)));
 
                     return GetOccurrenceByStructureAndRelations(s, notAllowedRelations);
                 })
@@ -106,9 +106,9 @@ namespace ErosionFinder.Helpers
                 .Select(s => 
                 {
                     var notAllowedRelations = s.Relations
-                        .Where(r => RelationTypeIsInDefinedList(r, relationTypes) 
-                            && targetNamespaces.Any(n => n.Equals(r.Target))
-                            && !s.Namespace.Equals(r.Target));
+                        .Where(r => !s.Namespace.Equals(r.Target)
+                            && RelationTypeIsInDefinedList(r, relationTypes) 
+                            && targetNamespaces.Any(n => n.Equals(r.Target)));
 
                     return GetOccurrenceByStructureAndRelations(s, notAllowedRelations);
                 })

--- a/Source/ErosionFinder/Helpers/ArchitecturalRuleHelper.cs
+++ b/Source/ErosionFinder/Helpers/ArchitecturalRuleHelper.cs
@@ -87,7 +87,8 @@ namespace ErosionFinder.Helpers
                 {
                     var notAllowedRelations = s.Relations
                         .Where(r => RelationTypeIsInDefinedList(r, relationTypes) 
-                            && targetNamespaces.Any(n => n.Equals(r.Target)));
+                            && targetNamespaces.Any(n => n.Equals(r.Target))
+                            && !s.Namespace.Equals(r.Target));
 
                     return GetOccurrenceByStructureAndRelations(s, notAllowedRelations);
                 })
@@ -106,7 +107,8 @@ namespace ErosionFinder.Helpers
                 {
                     var notAllowedRelations = s.Relations
                         .Where(r => RelationTypeIsInDefinedList(r, relationTypes) 
-                            && targetNamespaces.Any(n => n.Equals(r.Target)));
+                            && targetNamespaces.Any(n => n.Equals(r.Target))
+                            && !s.Namespace.Equals(r.Target));
 
                     return GetOccurrenceByStructureAndRelations(s, notAllowedRelations);
                 })


### PR DESCRIPTION
Fix 'relations to itself' scenario when the architectural rule is of 'only' type